### PR TITLE
update config for autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ## Process this file with automake to produce Makefile.in
 AUTOMAKE_OPTIONS = gnu dist-bzip2
 
-INCLUDES = -I$(srcdir) $(VERSION_FLAGS)
+AM_CPPFLAGS = -I$(srcdir) $(VERSION_FLAGS)
 SUBDIRS = @subdirs@ @SASL_PLUGINS@
 DIST_SUBDIRS = @subdirs@ @DIST_PLUGINS@
 AM_CFLAGS = @CFLAGS@ @EXTRA_CFLAGS@

--- a/acconfig.h
+++ b/acconfig.h
@@ -1,8 +1,0 @@
-/* Turn off the GCC specific __attribute__ keyword */
-#if !defined (__GNUC__) || __GNUC__ < 2
-# define __attribute__(x)
-#endif
-
-@TOP@
-
-@BOTTOM@

--- a/configure.ac
+++ b/configure.ac
@@ -24,9 +24,10 @@ dnl Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 dnl 
 dnl #########################################################################
 
-AC_INIT(smtp-api.c)
-AM_CONFIG_HEADER(config.h)
-AM_INIT_AUTOMAKE([libesmtp],[1.0.6])
+AC_INIT([libesmtp],[1.0.6.1])
+AC_CONFIG_SRCDIR([smtp-api.c])
+AM_INIT_AUTOMAKE
+AC_CONFIG_HEADERS(config.h)
 AC_CANONICAL_HOST
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/crammd5/Makefile.am
+++ b/crammd5/Makefile.am
@@ -2,7 +2,7 @@
 
 libdir = @plugindir@
 
-INCLUDES = -I@srcdir@
+AM_CPPFLAGS = -I@srcdir@
 AM_CFLAGS = @CFLAGS@ @EXTRA_CFLAGS@
 
 lib_LTLIBRARIES = sasl-cram-md5.la

--- a/login/Makefile.am
+++ b/login/Makefile.am
@@ -2,7 +2,7 @@
 
 libdir = @plugindir@
 
-INCLUDES = -I@srcdir@
+AM_CPPFLAGS = -I@srcdir@
 
 lib_LTLIBRARIES = sasl-login.la
 AM_CFLAGS = @CFLAGS@ @EXTRA_CFLAGS@

--- a/ntlm/Makefile.am
+++ b/ntlm/Makefile.am
@@ -2,7 +2,7 @@
 
 libdir = @plugindir@
 
-INCLUDES = -I@srcdir@
+AM_CPPFLAGS = -I@srcdir@
 AM_CFLAGS = @CFLAGS@ @EXTRA_CFLAGS@
 
 lib_LTLIBRARIES = sasl-ntlm.la

--- a/plain/Makefile.am
+++ b/plain/Makefile.am
@@ -2,7 +2,7 @@
 
 libdir = @plugindir@
 
-INCLUDES = -I@srcdir@
+AM_CPPFLAGS = -I@srcdir@
 AM_CFLAGS = @CFLAGS@ @EXTRA_CFLAGS@
 
 lib_LTLIBRARIES = sasl-plain.la


### PR DESCRIPTION
Signed-off-by: Othmar Trungier <github@truniger.ch>

I updated different files according to warnings in order to prevent them and updated configure.ac according to
https://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation

I updated the version in configure.ac to 1.0.6.1 to prepare for next minor release.

I'm not sure about acconfig.h. It is deprecated and discouraged to use. It applies to __GNUC__ < 2 which I guess is not relevant anymore, so I just deleted it.

With these changes the config for autotools should be up-to-date and there are no warnings anymore 