### PR TITLE
Update to correct SONAME version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -208,7 +208,7 @@ vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfil
 
 lib = library('esmtp', sources,
 	      link_args : vflag, link_depends : mapfile,
-	      soversion : libesmtp_so_version,
+	      version : libesmtp_so_version,
 	      dependencies : deps,
 	      install : true)
 


### PR DESCRIPTION
Pass as `version`  rather than `soversion` to allow Meson to manage the SONAME version.

When building 1.1.0 I noticed the SONAME was being set to libesmtp.so.6.2.0 where it had previously been set to libesmtp.so.6 with the previous builds of 1.0.6. I identified that Meson would take `soversion` as literal value when passed to `library()` but if passed as `version` it properly set the SONAME using only the major value of the version tuple as expected.