### PR TITLE
enhance template file test-mail

### DIFF
--- a/examples/test-mail
+++ b/examples/test-mail
@@ -3,6 +3,7 @@ MIME-Version: 1.0
 Content-Type: text/plain;
   charset=iso-8859-1
 Content-Transfer-Encoding: 7bit
+Subject: subject text
 
 Hello world!
 ..


### PR DESCRIPTION
A subject seems to only be overridable by the lib (command line switch `-s`) if there is a default subject specified in the template file. Otherwise regardless whether `-s` option is specified or not, the subject stays empty in the resulting mail.

Seeking for a possibility on how to hard set a subject via the lib, without having it specified in the template.