### PR TITLE
Add support for macOS

### DIFF
--- a/examples/mail-file.c
+++ b/examples/mail-file.c
@@ -22,7 +22,7 @@
    Error checking is minimal to non-existent, this is just a quick
    and dirty program to give a feel for using libESMTP.
  */
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600L
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/libesmtp.darwin.map
+++ b/libesmtp.darwin.map
@@ -1,0 +1,4 @@
+_smtp_*
+__smtp_*
+_auth_*
+

--- a/meson.build
+++ b/meson.build
@@ -93,8 +93,8 @@ have_gmtoff = cc.has_member('struct tm', 'tm_gmtoff',
                             prefix: '#include <time.h>')
 have_timezone = cc.has_header_symbol('time.h', 'timezone',
                                      args: '-D_XOPEN_SOURCE=700')
-
-
+have_strerror_r_char_p = not cc.compiles('#include <string.h>\nint strerror_r(int,char*,size_t);int main(){}')
+have_strerror_r = cc.has_function('strerror_r')
 
 ################################################################################
 # configuration
@@ -131,8 +131,8 @@ conf.set('HAVE_GETHOSTNAME', 1, description : 'POSIX.1-2001, POSIX.1-2008.')
 conf.set('HAVE_GETTIMEOFDAY', true, description : 'POSIX.1-2001, obsolete POSIX.1-2008.')
 conf.set('HAVE_LIBCRYPTO', ssldep.found().to_int())
 conf.set('HAVE_LWRES_NETDB_H', lwresdep.found().to_int())
-conf.set10('HAVE_STRERROR_R', not gnu_source)
-conf.set10('HAVE_GNU_STRERROR_R', gnu_source)
+conf.set10('HAVE_STRERROR_R', have_strerror_r and not have_strerror_r_char_p)
+conf.set10('HAVE_GNU_STRERROR_R', have_strerror_r_char_p)
 conf.set('HAVE_UNAME', 1)
 
 conf.set10('HAVE_LOCALTIME_R', have_localtime_r)

--- a/meson.build
+++ b/meson.build
@@ -222,11 +222,25 @@ if ssldep.found()
   sources += [ 'tlsutils.h', 'tlsutils.c' ]
 endif
 
-mapfile = 'libesmtp.map'
-vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)
+gnu_map_file = 'libesmtp.map'
+darwin_map_file = 'libesmtp.darwin.map'
+
+libesmtp_gnu_sym_path = join_paths(meson.current_source_dir(), gnu_map_file)
+libesmtp_gnu_sym_ldflag = '-Wl,--version-script=' + libesmtp_gnu_sym_path
+libesmtp_darwin_sym_path = join_paths(meson.current_source_dir(), darwin_map_file)
+# On FreeBSD, -Wl,--version-script only works with -shared
+if cc.links('', name: '-Wl,--version-script', args: ['-shared', libesmtp_gnu_sym_ldflag])
+    # GNU ld
+    link_args = [libesmtp_gnu_sym_ldflag]
+elif host_machine.system() == 'darwin' and cc.has_multi_link_arguments('-Wl,-exported_symbols_list', libesmtp_darwin_sym_path)
+    # Clang on Darwin
+    link_args = ['-Wl,-exported_symbols_list', libesmtp_darwin_sym_path]
+else
+    error('Linker doesn\'t support --version-script or -exported_symbols_list')
+endif
 
 lib = library('esmtp', sources,
-	      link_args : vflag, link_depends : mapfile,
+	      link_args : link_args, link_depends : [gnu_map_file, darwin_map_file],
 	      version : libesmtp_so_version,
 	      dependencies : deps,
 	      install : true)


### PR DESCRIPTION
This adds support for macOS.

In the build environment:

1. Check for strerror_r() variants explicitly with a compile test.
2. Detect ld support for --version-script and -exported_symbols_list and use whichever is available.

In the example app:

1. Bump _XOPEN_SOURCE to 600 so that snprintf() is available.
2. Replace getpass(), as it's now gone completely.

It compiles cleanly and the demo app seems to do the right thing on both macOS (14.5/M2) and Linux (RHEL9/x86).

I've not tested the getpass() replacement yet, I need to persuade it to look in the right place for authentication plugins first.