### PR TITLE
Add support macOS

### DIFF
--- a/auth-client.c
+++ b/auth-client.c
@@ -89,6 +89,19 @@ struct auth_context
 # define PLUGIN_DIR
 #endif
 
+#ifdef STATIC_AUTH_PLAIN
+extern struct auth_client_plugin sasl_client_plain;
+#endif
+#ifdef STATIC_AUTH_LOGIN
+extern struct auth_client_plugin sasl_client_login;
+#endif
+#ifdef STATIC_AUTH_NTLM
+extern struct auth_client_plugin sasl_client_ntlm;
+#endif
+#ifdef STATIC_AUTH_CRAMMD5
+extern struct auth_client_plugin sasl_client_crammd5;
+#endif
+
 static char *
 plugin_name (const char *str)
 {
@@ -177,6 +190,18 @@ load_client_plugin (const char *name)
 void
 auth_client_init (void)
 {
+#ifdef STATIC_AUTH_PLAIN
+    append_plugin(NULL, &sasl_client_plain);
+#endif
+#ifdef STATIC_AUTH_LOGIN
+    append_plugin(NULL, &sasl_client_login);
+#endif
+#ifdef STATIC_AUTH_NTLM
+    append_plugin(NULL, &sasl_client_ntlm);
+#endif
+#ifdef STATIC_AUTH_CRAMMD5
+    append_plugin(NULL, &sasl_client_crammd5);
+#endif
 }
 
 /**

--- a/crammd5/client-crammd5.c
+++ b/crammd5/client-crammd5.c
@@ -39,7 +39,13 @@ static const char *crammd5_response (void *ctx,
 				     const char *challenge, int *len,
 				     auth_interact_t interact, void *arg);
 
-const struct auth_client_plugin sasl_client =
+const struct auth_client_plugin
+#ifdef STATIC_AUTH_CRAMMD5
+        sasl_client_crammd5
+#else
+        sasl_client
+#endif
+        =
   {
   /* Plugin information */
     "CRAM-MD5",

--- a/crammd5/meson.build
+++ b/crammd5/meson.build
@@ -16,7 +16,7 @@ else
 endif
 
 if static_auths.contains('crammd5')
-    foreach source : crammd5_login_sources
+    foreach source : sasl_crammd5_sources
         sources += 'crammd5' / source
     endforeach
 else

--- a/crammd5/meson.build
+++ b/crammd5/meson.build
@@ -1,24 +1,30 @@
 sasl_crammd5_sources = [
-  'client-crammd5.c',
-  'hmacmd5.c',
-  'hmacmd5.h',
+    'client-crammd5.c',
+    'hmacmd5.c',
+    'hmacmd5.h',
 ]
 
-crammd5_deps = [ ]
+crammd5_deps = []
 
 if conf.get('USE_TLS')
-  crammd5_deps += ssldep
+    crammd5_deps += ssldep
 else
-  sasl_crammd5_sources += [
-    'md5.c',
-    'md5.h',
-  ]
+    sasl_crammd5_sources += [
+        'md5.c',
+        'md5.h',
+    ]
 endif
 
-sasl_crammd5 = shared_module('crammd5', sasl_crammd5_sources,
-			     name_prefix : 'sasl-',
-			     dependencies : crammd5_deps,
-			     include_directories: [ include_dir, ],
-			     install : true,
-			     install_dir: auth_plugin_dir)
-clients += sasl_crammd5
+if static_auths.contains('crammd5')
+    foreach source : crammd5_login_sources
+        sources += 'crammd5' / source
+    endforeach
+else
+    sasl_crammd5 = shared_module('crammd5', sasl_crammd5_sources,
+                                 name_prefix : 'sasl-',
+                                 dependencies : crammd5_deps,
+                                 include_directories : [include_dir, ],
+                                 install : true,
+                                 install_dir : auth_plugin_dir)
+    clients += sasl_crammd5
+endif

--- a/examples/mail-file.c
+++ b/examples/mail-file.c
@@ -22,7 +22,7 @@
    Error checking is minimal to non-existent, this is just a quick
    and dirty program to give a feel for using libESMTP.
  */
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600L
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/mail-file.c
+++ b/examples/mail-file.c
@@ -389,7 +389,6 @@ authinteract (auth_client_request_t request, char **result, int fields,
   static char resp[512];
   char *p, *rp;
   int i, n, tty;
-
   rp = resp;
   for (i = 0; i < fields; i++)
     {
@@ -433,7 +432,6 @@ authinteract (auth_client_request_t request, char **result, int fields,
 int
 tlsinteract (char *buf, int buflen, int rwflag unused, void *arg unused)
 {
-  char *pw;
   int len, n;
   int tty;
   char prompt[64];

--- a/headers.c
+++ b/headers.c
@@ -170,7 +170,7 @@ print_message_id (smtp_message_t message, struct rfc2822_header *header)
     {
 #ifdef HAVE_GETTIMEOFDAY
       if (gettimeofday (&tv, NULL) != -1) /* This shouldn't fail ... */
-	snprintf (buf, sizeof buf, "%ld.%ld.%d@%s", tv.tv_sec, tv.tv_usec,
+	snprintf (buf, sizeof buf, "%ld.%ld.%d@%s", tv.tv_sec, (long)tv.tv_usec,
 		  getpid (), message->session->localhost);
       else /* ... but if it does fall back to using time() */
 #endif

--- a/libesmtp.darwin.map
+++ b/libesmtp.darwin.map
@@ -1,0 +1,4 @@
+_smtp_*
+__smtp_*
+_auth_*
+

--- a/login/client-login.c
+++ b/login/client-login.c
@@ -38,7 +38,13 @@ static const char *login_response (void *ctx,
 				   const char *challenge, int *len,
 				   auth_interact_t interact, void *arg);
 
-const struct auth_client_plugin sasl_client =
+const struct auth_client_plugin
+#ifdef STATIC_AUTH_LOGIN
+        sasl_client_login
+#else
+        sasl_client
+#endif
+        =
   {
   /* Plugin information */
     "LOGIN",

--- a/login/meson.build
+++ b/login/meson.build
@@ -1,10 +1,16 @@
 sasl_login_sources = [
-  'client-login.c'
+    'client-login.c'
 ]
 
-sasl_login = shared_module('login', sasl_login_sources,
-			   name_prefix : 'sasl-',
-			   include_directories: [ include_dir, ],
-			   install : true,
-			   install_dir: auth_plugin_dir)
-clients += sasl_login
+if static_auths.contains('login')
+    foreach source : sasl_login_sources
+        sources += 'login' / source
+    endforeach
+else
+    sasl_login = shared_module('login', sasl_login_sources,
+                               name_prefix : 'sasl-',
+                               include_directories : [include_dir, ],
+                               install : true,
+                               install_dir : auth_plugin_dir)
+    clients += sasl_login
+endif

--- a/meson.build
+++ b/meson.build
@@ -151,6 +151,10 @@ conf.set('HAVE_STRCASECMP', have_strcasecmp)
 conf.set('HAVE_MEMRCHR', have_memrchr)
 conf.set('HAVE_STRLCPY', have_strlcpy)
 
+if target_machine.system() == 'darwin'
+  conf.set_quoted('DLEXT', '.dylib')
+endif
+
 configure_file(output : 'config.h', configuration : conf)
 
 ################################################################################

--- a/meson.build
+++ b/meson.build
@@ -110,6 +110,23 @@ elif xopen_source
 else
     conf.set('_POSIX_C_SOURCE', '200809L')
 endif
+
+static_auths = get_option('staticauth')
+if static_auths.contains('all')
+    static_auths = ['login', 'plain', 'crammd5']
+    if ntlmdeps.found()
+        static_auths += 'ntlm'
+    endif
+endif
+
+if static_auths.contains('ntlm') and not ntlmdeps.found()
+    error('NTLM depencies not found, cannot embed NTLM authentication statically')
+endif
+
+foreach auth : static_auths
+  conf.set('STATIC_AUTH_' + auth.to_upper(), 1)
+endforeach
+
 conf.set('SIZEOF_UNSIGNED_INT', cc.sizeof('unsigned int'))
 conf.set('SIZEOF_UNSIGNED_LONG', cc.sizeof('unsigned long'))
 conf.set('SIZEOF_UNSIGNED_SHORT', cc.sizeof('unsigned short'))
@@ -226,6 +243,26 @@ if ssldep.found()
   sources += [ 'tlsutils.h', 'tlsutils.c' ]
 endif
 
+################################################################################
+# SASL client modules
+################################################################################
+clients = []
+include_dir = include_directories('.')
+subdir('login')
+subdir('plain')
+subdir('crammd5')
+if ntlmdep.found()
+    if cc.has_header('openssl/md4.h') and cc.has_function('MD4_Init', dependencies : ntlmdep)
+        subdir('ntlm')
+    else
+        error('MD4 is not supported in current openssl, unable to build NTLM plugin')
+    endif
+endif
+
+################################################################################
+# Main library
+################################################################################
+
 gnu_map_file = 'libesmtp.map'
 darwin_map_file = 'libesmtp.darwin.map'
 
@@ -249,21 +286,7 @@ lib = library('esmtp', sources,
 	      dependencies : deps,
 	      install : true)
 
-################################################################################
-# SASL client modules
-################################################################################
-clients = []
-include_dir = include_directories('.')
-subdir('login')
-subdir('plain')
-subdir('crammd5')
-if ntlmdep.found()
-  if cc.has_header('openssl/md4.h') and cc.has_function('MD4_Init', dependencies : ntlmdep)
-    subdir('ntlm')
-  else
-    error('MD4 is not supported in current openssl, unable to build NTLM plugin')
-  endif
-endif
+
 
 ################################################################################
 # libESMTP example/demo program

--- a/meson.build
+++ b/meson.build
@@ -93,8 +93,8 @@ have_gmtoff = cc.has_member('struct tm', 'tm_gmtoff',
                             prefix: '#include <time.h>')
 have_timezone = cc.has_header_symbol('time.h', 'timezone',
                                      args: '-D_XOPEN_SOURCE=700')
-
-
+have_strerror_r_char_p = not cc.compiles('#include <string.h>\nint strerror_r(int,char*,size_t);int main(){}')
+have_strerror_r = cc.has_function('strerror_r')
 
 ################################################################################
 # configuration
@@ -131,8 +131,8 @@ conf.set('HAVE_GETHOSTNAME', 1, description : 'POSIX.1-2001, POSIX.1-2008.')
 conf.set('HAVE_GETTIMEOFDAY', true, description : 'POSIX.1-2001, obsolete POSIX.1-2008.')
 conf.set('HAVE_LIBCRYPTO', ssldep.found().to_int())
 conf.set('HAVE_LWRES_NETDB_H', lwresdep.found().to_int())
-conf.set10('HAVE_STRERROR_R', not gnu_source)
-conf.set10('HAVE_GNU_STRERROR_R', gnu_source)
+conf.set10('HAVE_STRERROR_R', have_strerror_r and not have_strerror_r_char_p)
+conf.set10('HAVE_GNU_STRERROR_R', have_strerror_r_char_p)
 conf.set('HAVE_UNAME', 1)
 
 conf.set10('HAVE_LOCALTIME_R', have_localtime_r)

--- a/meson.build
+++ b/meson.build
@@ -222,11 +222,25 @@ if ssldep.found()
   sources += [ 'tlsutils.h', 'tlsutils.c' ]
 endif
 
-mapfile = 'libesmtp.map'
-vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)
+gnu_map_file = 'libesmtp.map'
+darwin_map_file = 'libesmtp.darwin.map'
+
+libesmtp_gnu_sym_path = join_paths(meson.current_source_dir(), gnu_map_file)
+libesmtp_gnu_sym_ldflag = '-Wl,--version-script=' + libesmtp_gnu_sym_path
+libesmtp_darwin_sym_path = join_paths(meson.current_source_dir(), darwin_map_file)
+# On FreeBSD, -Wl,--version-script only works with -shared
+if cc.links('', name: '-Wl,--version-script', args: ['-shared', libesmtp_gnu_sym_ldflag])
+    # GNU ld
+    link_args = [libesmtp_gnu_sym_ldflag]
+elif host_machine.system() == 'darwin' and cc.has_multi_link_arguments('-Wl,-exported_symbols_list', libesmtp_darwin_sym_path)
+    # Clang on Darwin
+    link_args = ['-Wl,-exported_symbols_list', libesmtp_darwin_sym_path]
+else
+    error('Linker doesn\'t support --version-script or -exported_symbols_list')
+endif
 
 lib = library('esmtp', sources,
-	      link_args : vflag, link_depends : mapfile,
+	      link_args : link_args, link_depends : [gnu_map_file, darwin_map_file],
 	      version : libesmtp_so_version,
 	      dependencies : deps,
 	      install : true)

--- a/meson.build
+++ b/meson.build
@@ -114,12 +114,12 @@ endif
 static_auths = get_option('staticauth')
 if static_auths.contains('all')
     static_auths = ['login', 'plain', 'crammd5']
-    if ntlmdeps.found()
+    if ntlmdep.found()
         static_auths += 'ntlm'
     endif
 endif
 
-if static_auths.contains('ntlm') and not ntlmdeps.found()
+if static_auths.contains('ntlm') and not ntlmdep.found()
     error('NTLM depencies not found, cannot embed NTLM authentication statically')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,4 @@ option('bdat', type : 'boolean', value : 'true', description : 'enable SMTP BDAT
 option('etrn', type : 'boolean', value : 'true', description : 'enable SMTP ETRN extension')
 option('xusr', type : 'boolean', value : 'true', description : 'enable sendmail XUSR extension')
 option('ntlm', type : 'feature', value : 'disabled', description : 'build with support for NTLM authentication')
+option('staticauth', type : 'array', value : [], choices : ['all', 'plain', 'login', 'ntlm', 'crammd5'], description : 'bundle authentication methods statically')

--- a/ntlm/client-ntlm.c
+++ b/ntlm/client-ntlm.c
@@ -51,7 +51,13 @@ static const char *ntlm_response (void *ctx,
 				  const char *challenge, int *len,
 				  auth_interact_t interact, void *arg);
 
-const struct auth_client_plugin sasl_client =
+const struct auth_client_plugin
+#ifdef STATIC_AUTH_NTLM
+        sasl_client_ntlm
+#else
+        sasl_client
+#endif
+        =
   {
   /* Plugin information */
     "NTLM",

--- a/ntlm/meson.build
+++ b/ntlm/meson.build
@@ -1,16 +1,22 @@
 sasl_ntlm_sources = [
-  'client-ntlm.c',
-  'ntlmdes.c',
-  'ntlm.h',
-  'ntlmstruct.c',
+    'client-ntlm.c',
+    'ntlmdes.c',
+    'ntlm.h',
+    'ntlmstruct.c',
 ]
 
-ntlm_deps = [ ntlmdep, ]
+if static_auth.contains('ntlm')
+    foreach source : sasl_ntlm_sources
+        sources += 'ntlm' / source
+    endforeach
+else
+    ntlm_deps = [ntlmdep, ]
 
-sasl_ntlm = shared_module('ntlm', sasl_ntlm_sources,
-			  name_prefix : 'sasl-',
-			  dependencies : ntlm_deps,
-			  include_directories: [ include_dir, ],
-			  install : true,
-			  install_dir: auth_plugin_dir)
-clients += sasl_ntlm
+    sasl_ntlm = shared_module('ntlm', sasl_ntlm_sources,
+                              name_prefix : 'sasl-',
+                              dependencies : ntlm_deps,
+                              include_directories : [include_dir, ],
+                              install : true,
+                              install_dir : auth_plugin_dir)
+    clients += sasl_ntlm
+endif

--- a/plain/client-plain.c
+++ b/plain/client-plain.c
@@ -37,7 +37,13 @@ static void plain_destroy (void *ctx);
 static const char *plain_response (void *ctx, const char *challenge, int *len,
 				   auth_interact_t interact, void *arg);
 
-const struct auth_client_plugin sasl_client =
+const struct auth_client_plugin
+#ifdef STATIC_AUTH_PLAIN
+        sasl_client_plain
+#else
+        sasl_client
+#endif
+        =
   {
   /* Plugin information */
     "PLAIN",

--- a/plain/meson.build
+++ b/plain/meson.build
@@ -1,10 +1,16 @@
 sasl_plain_sources = [
-  'client-plain.c'
+    'client-plain.c'
 ]
 
-sasl_plain = shared_module('plain', sasl_plain_sources,
-			   name_prefix : 'sasl-',
-			   include_directories: [ include_dir, ],
-			   install : true,
-			   install_dir: auth_plugin_dir)
-clients += sasl_plain
+if static_auths.contains('plain')
+    foreach source : sasl_plain_sources
+        sources += 'plain' / source
+    endforeach
+else
+    sasl_plain = shared_module('plain', sasl_plain_sources,
+                               name_prefix : 'sasl-',
+                               include_directories : [include_dir, ],
+                               install : true,
+                               install_dir : auth_plugin_dir)
+    clients += sasl_plain
+endif


### PR DESCRIPTION
This adds support for macOS.

In the library and build environment:

1. Check for strerror_r() variants explicitly with a compile test
2. Detect ld support for --version-script and -exported_symbols_list and use whichever is available
3. Use .dylib instead of .so for plugin suffixes on a macOS target

In the example app:

1. Bump _XOPEN_SOURCE to 600 so that snprintf() is available
2. Replace getpass(), as it's now gone completely

It compiles cleanly and the demo app seems to do the right thing, at least for STARTTLS / plain authentication, on both macOS (14.5/M2) and Linux (RHEL9/x86).